### PR TITLE
Update source building instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,15 @@ On Debian/Ubuntu/Mint
 
 To build from source
 
-On Fedora 17+ with Python 2:
+On Fedora 21+ with Python 2:
 
-    sudo dnf install git python-pip gcc python-devel systemd-devel
-    pip-python install git+http://github.com/systemd/python-systemd.git#egg=systemd
+    dnf install git python-pip gcc python-devel systemd-devel
+    pip install git+https://github.com/systemd/python-systemd.git#egg=systemd
 
-On Fedora 17+ with Python 3:
+On Fedora 21+ with Python 3:
 
-    sudo dnf install git python3-pip gcc python3-devel systemd-devel
-    pip-python3 install git+http://github.com/systemd/python-systemd.git#egg=systemd
+    dnf install git python3-pip gcc python3-devel systemd-devel
+    pip3 install git+https://github.com/systemd/python-systemd.git#egg=systemd
 
 Usage
 =====


### PR DESCRIPTION
* Only list Fedora 21+. Older releases are no longer supported by upstream, let alone for systemd development.
* Fedora now uses `pip` and `pip3`, not `pip-python` and `pip-python3`. By only documenting Fedora 21+, we can be consistent in the instructions.
* Use HTTPS for git (rather than HTTP).