### PR TITLE
Fix daemon.is_fifo and .is_mq under Python 3

### DIFF
--- a/systemd/_daemon.c
+++ b/systemd/_daemon.c
@@ -142,9 +142,12 @@ static PyObject* is_fifo(PyObject *self, PyObject *args) {
         const char *path = NULL;
 
 #if PY_MAJOR_VERSION >=3 && PY_MINOR_VERSION >= 1
+        _cleanup_Py_DECREF_ PyObject *_path = NULL;
         if (!PyArg_ParseTuple(args, "i|O&:_is_fifo",
-                              &fd, Unicode_FSConverter, &path))
+                              &fd, Unicode_FSConverter, &_path))
                 return NULL;
+	if (_path)
+		path = PyBytes_AsString(_path);
 #else
         if (!PyArg_ParseTuple(args, "i|z:_is_fifo", &fd, &path))
                 return NULL;
@@ -170,9 +173,12 @@ static PyObject* is_mq(PyObject *self, PyObject *args) {
         const char *path = NULL;
 
 #if PY_MAJOR_VERSION >=3 && PY_MINOR_VERSION >= 1
+        _cleanup_Py_DECREF_ PyObject *_path = NULL;
         if (!PyArg_ParseTuple(args, "i|O&:_is_mq",
-                              &fd, Unicode_FSConverter, &path))
+                              &fd, Unicode_FSConverter, &_path))
                 return NULL;
+	if (_path)
+		path = PyBytes_AsString(_path);
 #else
         if (!PyArg_ParseTuple(args, "i|z:_is_mq", &fd, &path))
                 return NULL;


### PR DESCRIPTION
The 'path' parameter was not properly converted from Unicode
and the functions would always fail when a path was provided.

Test code:
```python
#!/usr/bin/python3

import os
import posix
from systemd.daemon import _is_fifo

posix.mkfifo("test.fifo")
try:
    assert not _is_fifo(0, None)
    assert not _is_fifo(0, "test.fifo")
    fd = os.open("test.fifo", os.O_RDONLY|os.O_NONBLOCK)
    assert _is_fifo(fd, None)
    assert _is_fifo(fd, "test.fifo")
finally:
    os.unlink("test.fifo")
```