### PR TITLE
Generate systemd/id128-constants.h in setup.py. Fixes #7.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,7 @@ builddir := $(shell $(PYTHON) -c '$(buildscript)')
 
 all: build
 
-systemd/id128-constants.h: $(INCLUDE_DIR)/systemd/sd-messages.h
-	$(SED) -n -r 's/,//g; s/#define (SD_MESSAGE_[A-Z0-9_]+)\s.*/add_id(m, "\1", \1) JOINER/p' <$< >$@
-
-build: systemd/id128-constants.h
+build:
 	$(PYTHON) setup.py build
 
 install:


### PR DESCRIPTION
This generates systemd/id128-constants.h in setup.py instead of the Makefile. Tools like pip don't call make, but only setup.py. With this patch the pip install example from the README works again.