### PR TITLE
Fixes Reader.seek_monotonic(datetime.timedelta)

### DIFF
--- a/systemd/journal.py
+++ b/systemd/journal.py
@@ -291,7 +291,7 @@ class Reader(_Reader):
         is reference to. Defaults to current bootid.
         """
         if isinstance(monotonic, _datetime.timedelta):
-            monotonic = monotonic.totalseconds()
+            monotonic = monotonic.total_seconds()
         monotonic = int(monotonic * 1000000)
         if isinstance(bootid, _uuid.UUID):
             bootid = bootid.hex


### PR DESCRIPTION
Python 2.7/3.2 introduce a function [`timedelta.total_seconds()`](https://docs.python.org/3/library/datetime.html#timedelta-objects). The function `timedelta.totalseconds()` used previously is undefined.