### PR TITLE
test_daemon: Define a default value for SO_PASSCRED

### DIFF
--- a/systemd/test/test_daemon.py
+++ b/systemd/test/test_daemon.py
@@ -228,7 +228,9 @@ def test_notify_with_socket(tmpdir):
     path = tmpdir.join('socket').strpath
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
     sock.bind(path)
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_PASSCRED, 1)
+    # SO_PASSCRED is not defined in python2.7
+    SO_PASSCRED = getattr(socket, 'SO_PASSCRED', 16)
+    sock.setsockopt(socket.SOL_SOCKET, SO_PASSCRED, 1)
     os.environ['NOTIFY_SOCKET'] = path
 
     assert notify('READY=1') == True


### PR DESCRIPTION
The socket module seems to be missing this in python2.7.