### PR TITLE
readme: Remove duplicate 'is thrown'

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Notes:
    printf-style substitution is not supported. Perform any
    substitution using Python's % operator or .format() capabilities
    first.
- * A ValueError is thrown if sd_journald_sendv() results in an error.
+ * A ValueError is raised if sd_journald_sendv() results in an error.
    This might happen if there are no arguments or one of them is
    invalid.
 

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ Notes:
    printf-style substitution is not supported. Perform any
    substitution using Python's % operator or .format() capabilities
    first.
- * A ValueError is thrown is thrown if sd_journald_sendv() results in
-   an error. This might happen if there are no arguments or one of them
-   is invalid.
+ * A ValueError is thrown if sd_journald_sendv() results in an error.
+   This might happen if there are no arguments or one of them is
+   invalid.
 
 Viewing Output
 ==============


### PR DESCRIPTION
readme: Minor fixes:
- remove duplicate 'is thrown'
- Use "raised" instead of "thrown"