### PR TITLE
Include all fields from record + additional fields with exception info if any

### DIFF
--- a/systemd/journal.py
+++ b/systemd/journal.py
@@ -559,15 +559,30 @@ class JournalHandler(_logging.Handler):
             msg = self.format(record)
             pri = self.mapPriority(record.levelno)
             mid = getattr(record, 'MESSAGE_ID', None)
+            extras = { k:str(v) for k,v in self._extra.iteritems() }
+            extras.update({
+                k:str(v) for k,v in record.__dict__.iteritems()
+            })
+
+            if record.exc_text:
+                extras['EXCEPTION_TEXT'] = record.exc_text
+
+            if record.exc_info:
+                extras['EXCEPTION_INFO'] = record.exc_info
+
+            if record.args:
+                extras['CODE_ARGS'] = str(record.args)
+
             send(msg,
                  MESSAGE_ID=mid,
                  PRIORITY=format(pri),
                  LOGGER=record.name,
                  THREAD_NAME=record.threadName,
+                 PROCESS_NAME=record.processName,
                  CODE_FILE=record.pathname,
                  CODE_LINE=record.lineno,
                  CODE_FUNC=record.funcName,
-                 **self._extra)
+                 **extras)
         except Exception:
             self.handleError(record)
 


### PR DESCRIPTION
This approach allows to use LoggerAdapter+extra or .info(.., extra={})
to transparently add extra fields to journal.