### PR TITLE
replace dict.iteritems() with dict.items() to support py3

### DIFF
--- a/systemd/journal.py
+++ b/systemd/journal.py
@@ -546,6 +546,8 @@ class JournalHandler(_logging.Handler):
                 raise ValueError('Invalid field name: ' + name)
         if 'SYSLOG_IDENTIFIER' not in kwargs:
             kwargs['SYSLOG_IDENTIFIER'] = _sys.argv[0]
+
+        self.send = kwargs.pop('SENDER_FUNCTION', send)
         self._extra = kwargs
 
     def emit(self, record):
@@ -559,9 +561,9 @@ class JournalHandler(_logging.Handler):
             msg = self.format(record)
             pri = self.mapPriority(record.levelno)
             mid = getattr(record, 'MESSAGE_ID', None)
-            extras = { k:str(v) for k,v in self._extra.iteritems() }
+            extras = { k:str(v) for k,v in self._extra.items() }
             extras.update({
-                k:str(v) for k,v in record.__dict__.iteritems()
+                k:str(v) for k,v in record.__dict__.items()
             })
 
             if record.exc_text:
@@ -573,16 +575,16 @@ class JournalHandler(_logging.Handler):
             if record.args:
                 extras['CODE_ARGS'] = str(record.args)
 
-            send(msg,
-                 MESSAGE_ID=mid,
-                 PRIORITY=format(pri),
-                 LOGGER=record.name,
-                 THREAD_NAME=record.threadName,
-                 PROCESS_NAME=record.processName,
-                 CODE_FILE=record.pathname,
-                 CODE_LINE=record.lineno,
-                 CODE_FUNC=record.funcName,
-                 **extras)
+            self.send(msg,
+                      MESSAGE_ID=mid,
+                      PRIORITY=format(pri),
+                      LOGGER=record.name,
+                      THREAD_NAME=record.threadName,
+                      PROCESS_NAME=record.processName,
+                      CODE_FILE=record.pathname,
+                      CODE_LINE=record.lineno,
+                      CODE_FUNC=record.funcName,
+                      **extras)
         except Exception:
             self.handleError(record)
 

--- a/systemd/test/test_journal.py
+++ b/systemd/test/test_journal.py
@@ -5,12 +5,39 @@ import logging
 import os
 import time
 import uuid
+import traceback as _traceback
 
 from systemd import journal, id128
+from systemd.journal import _make_line
 
 import pytest
 
 TEST_MID = uuid.UUID('8441372f8dca4ca98694a6091fd8519f')
+
+class MockSender:
+    def __init__(self):
+        self.buf = []
+
+    def send(self, MESSAGE, MESSAGE_ID=None,
+             CODE_FILE=None, CODE_LINE=None, CODE_FUNC=None,
+             **kwargs):
+        args = ['MESSAGE=' + MESSAGE]
+
+        if MESSAGE_ID is not None:
+            id = getattr(MESSAGE_ID, 'hex', MESSAGE_ID)
+            args.append('MESSAGE_ID=' + id)
+
+        if CODE_LINE == CODE_FILE == CODE_FUNC == None:
+            CODE_FILE, CODE_LINE, CODE_FUNC = _traceback.extract_stack(limit=2)[0][:3]
+        if CODE_FILE is not None:
+            args.append('CODE_FILE=' + CODE_FILE)
+        if CODE_LINE is not None:
+            args.append('CODE_LINE={:d}'.format(CODE_LINE))
+        if CODE_FUNC is not None:
+            args.append('CODE_FUNC=' + CODE_FUNC)
+
+        args.extend(_make_line(key, val) for key, val in kwargs.items())
+        self.buf.append(args)
 
 @contextlib.contextmanager
 def skip_enosys():
@@ -57,6 +84,15 @@ def test_journalhandler_init_exception():
 def test_journalhandler_init():
     kw = {'X':3, 'X3':4}
     journal.JournalHandler(logging.INFO, **kw)
+
+def test_journalhandler_info():
+    record = logging.LogRecord('test-logger', logging.INFO, 'testpath', 1, 'test', None, None)
+
+    sender = MockSender()
+    kw = {'X':3, 'X3':4, 'SENDER_FUNCTION': sender.send}
+    handler = journal.JournalHandler(logging.INFO, **kw)
+    handler.emit(record)
+    assert len(sender.buf) == 1
 
 def test_reader_init_flags():
     j1 = journal.Reader()


### PR DESCRIPTION
py3 doesn't have `dict.iteritems()` anymore so it fails under py3 env. So replace `dict.iteritems()` with `dict.items()`. `six.iteritems()` can be used but it requires `six` as a dependency library.

Previous test cases doesn't reveals the failure under py3 env so introduce a MockSender and inject sender function to increase testability.