### PR TITLE
test_daemon: xfail test_notify_with_socket if bind() fails

### DIFF
--- a/systemd/test/test_daemon.py
+++ b/systemd/test/test_daemon.py
@@ -238,7 +238,10 @@ def test_notify_bad_socket():
 def test_notify_with_socket(tmpdir):
     path = tmpdir.join('socket').strpath
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
-    sock.bind(path)
+    try:
+        sock.bind(path)
+    except socket.error as e:
+        pytest.xfail('failed to bind socket (%s)' % e)
     # SO_PASSCRED is not defined in python2.7
     SO_PASSCRED = getattr(socket, 'SO_PASSCRED', 16)
     sock.setsockopt(socket.SOL_SOCKET, SO_PASSCRED, 1)


### PR DESCRIPTION
This bind() call may fail if TMPDIR is too long.

Bug: https://bugs.gentoo.org/610368