### PR TITLE
Fix notify fs leak

### DIFF
--- a/systemd/_daemon.c
+++ b/systemd/_daemon.c
@@ -123,7 +123,7 @@ static PyObject* notify(PyObject *self, PyObject *args, PyObject *keywds) {
                         return NULL;
 
                 arr = PyMem_NEW(int, len);
-                if (!fds)
+                if (!arr)
                         return NULL;
 
                 for (i = 0; i < len; i++) {

--- a/systemd/_daemon.c
+++ b/systemd/_daemon.c
@@ -127,7 +127,7 @@ static PyObject* notify(PyObject *self, PyObject *args, PyObject *keywds) {
                         return NULL;
 
                 for (i = 0; i < len; i++) {
-                        PyObject *item = PySequence_GetItem(fds, i);
+                        _cleanup_Py_DECREF_ PyObject *item = PySequence_GetItem(fds, i);
                         if (!item)
                                 return NULL;
 


### PR DESCRIPTION
reproducible with 

```python
import sys
import systemd.daemon


fd = 1
fds = [fd]
ref_cnt = sys.getrefcount(fd)
systemd.daemon.notify('', True, 0, fds)
assert sys.getrefcount(fd) <= ref_cnt, 'leak'
```