### PR TITLE
journal: add extra parameter to JournalHandler constructor

### DIFF
--- a/systemd/journal.py
+++ b/systemd/journal.py
@@ -553,9 +553,11 @@ class JournalHandler(_logging.Handler):
     the `sender_function` parameter.
     """
 
-    def __init__(self, level=_logging.NOTSET, sender_function=send, **kwargs):
+    def __init__(self, level=_logging.NOTSET, extra=None, sender_function=send, **kwargs):
         super(JournalHandler, self).__init__(level)
 
+        if isinstance(extra, dict):
+            kwargs.update(extra)
         for name in kwargs:
             if not _valid_field_name(name):
                 raise ValueError('Invalid field name: ' + name)

--- a/systemd/test/test_journal.py
+++ b/systemd/test/test_journal.py
@@ -82,10 +82,13 @@ def test_journalhandler_init_exception():
     kw = {' X  ':3}
     with pytest.raises(ValueError):
         journal.JournalHandler(**kw)
+    with pytest.raises(ValueError):
+        journal.JournalHandler(logging.INFO, kw)
 
 def test_journalhandler_init():
     kw = {'X':3, 'X3':4}
     journal.JournalHandler(logging.INFO, **kw)
+    journal.JournalHandler(logging.INFO, kw)
 
 def test_journalhandler_info():
     record = logging.LogRecord('test-logger', logging.INFO, 'testpath', 1, 'test', None, None)
@@ -93,6 +96,21 @@ def test_journalhandler_info():
     sender = MockSender()
     kw = {'X':3, 'X3':4, 'sender_function': sender.send}
     handler = journal.JournalHandler(logging.INFO, **kw)
+    handler.emit(record)
+    assert len(sender.buf) == 1
+    assert 'X=3' in sender.buf[0]
+    assert 'X3=4' in sender.buf[0]
+
+    sender = MockSender()
+    handler = journal.JournalHandler(logging.INFO, {'X':3, 'X3':4}, sender_function=sender.send)
+    handler.emit(record)
+    assert len(sender.buf) == 1
+    assert 'X=3' in sender.buf[0]
+    assert 'X3=4' in sender.buf[0]
+
+    sender = MockSender()
+    kw = {'X3':4}
+    handler = journal.JournalHandler(logging.INFO, {'X':3}, sender_function=sender.send, **kw)
     handler.emit(record)
     assert len(sender.buf) == 1
     assert 'X=3' in sender.buf[0]


### PR DESCRIPTION
Hello,

`logging.config.fileConfig` supports only `args` which is a list of positional arguments.
https://docs.python.org/3/library/logging.config.html#configuration-file-format
But `JournalHandler` currently accepts only keyword arguments.

This change enables to add extra fields to JournalHandler in a configuration file.

```
class=systemd.journal.JournalHandler
args=(INFO, {'SYSLOG_IDENTIFIER': 'my-cool-app'})
```