### PR TITLE
add JournalHandler usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ Notes:
    This might happen if there are no arguments or one of them is
    invalid.
 
+A handler class for the Python logging framework is also provided:
+
+    import logging
+    from systemd import journal
+    logger = logging.getLogger('custom_logger_name')
+    logger.addHandler(journal.JournalHandler())
+    logger.warning("Some message: %s", 'detail')
+
 Documentation
 =============
 


### PR DESCRIPTION
I guess many people would like to search the handler class for the logging framework. However, the README doesn't provide a example for the `journal.JournalHandler`. Then they may turn to use other python wrappers like [mosquito/python-systemd](https://github.com/mosquito/python-systemd).

So I think the `journal.JournalHandler` example should be added in README.