### PR TITLE
Added support for sd_listen_fds_with_names()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,9 @@ CHANGES WITH 235:
 	* Adapt the rename of systemd-activate to systemd-socket-activate
 	  performed in systemd 230
 
+	* Support for the new sd_listen_fds_with_names added in systemd 227
+	  is added.
+
 CHANGES WITH 234:
 
         * Support for the new sd_is_socket_sockaddr added in systemd 233

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,10 @@
 Python wrappers for libsystemd API
 
+CHANGES WITH 235:
+
+	* Adapt the rename of systemd-activate to systemd-socket-activate
+	  performed in systemd 230
+
 CHANGES WITH 234:
 
         * Support for the new sd_is_socket_sockaddr added in systemd 233

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def lib(*names, **kw):
                      + '\n'.join(results) + '\n')
     sys.exit(status)
 
-version = '234'
+version = '235'
 defines = {'define_macros':[('PACKAGE_VERSION', '"{}"'.format(version))]}
 
 _journal = Extension('systemd/_journal',

--- a/systemd/_daemon.c
+++ b/systemd/_daemon.c
@@ -210,10 +210,13 @@ static PyObject* listen_fds(PyObject *self, PyObject *args, PyObject *keywds) {
 
 PyDoc_STRVAR(listen_fds_with_names__doc__,
              "_listen_fds_with_names(unset_environment=True) -> (int, str...)\n\n"
+             "Wraps sd_listen_fds_with_names(3).\n"
+#ifdef HAVE_SD_LISTEN_FDS_WITH_NAMES
              "Return the number of descriptors passed to this process by the init system\n"
              "and their names as part of the socket-based activation logic.\n"
-             "Wraps sd_listen_fds_with_names(3).\n"
-             "Raises RunTimeError if compiled under systemd < 227."
+#else
+             "NOT SUPPORTED: compiled without support sd_listen_fds_with_names"
+#endif
 );
 
 static void free_names(char **names) {

--- a/systemd/_daemon.c
+++ b/systemd/_daemon.c
@@ -217,9 +217,10 @@ PyDoc_STRVAR(listen_fds_with_names__doc__,
 );
 
 static void free_names(char **names) {
+	char **n;
         if (names == NULL)
                 return;
-        for (char **n = names; *n != NULL; n++)
+        for (n = names; *n != NULL; n++)
                 free(*n);
         free(names);
 }

--- a/systemd/daemon.py
+++ b/systemd/daemon.py
@@ -58,7 +58,7 @@ def listen_fds(unset_environment=True):
     Example::
 
       (in primary window)
-      $ systemd-activate -l 2000 python3 -c \\
+      $ systemd-socket-activate -l 2000 python3 -c \\
           'from systemd.daemon import listen_fds; print(listen_fds())'
       (in another window)
       $ telnet localhost 2000

--- a/systemd/daemon.py
+++ b/systemd/daemon.py
@@ -4,6 +4,7 @@ from ._daemon import (__version__,
                       booted,
                       notify,
                       _listen_fds,
+                      _listen_fds_with_names,
                       _is_fifo,
                       _is_socket,
                       _is_socket_inet,
@@ -69,3 +70,24 @@ def listen_fds(unset_environment=True):
     """
     num = _listen_fds(unset_environment)
     return list(range(LISTEN_FDS_START, LISTEN_FDS_START + num))
+
+def listen_fds_with_names(unset_environment=True):
+    """Return a dictionary of socket activated descriptors as {fd: name}
+
+    Example::
+
+      (in primary window)
+      $ systemd-socket-activate -l 2000 -l 4000 --fdname=2K:4K python3 -c \\
+          'from systemd.daemon import listen_fds_with_names; print(listen_fds_with_names())'
+      (in another window)
+      $ telnet localhost 2000
+      (in primary window)
+      ...
+      Execing python3 (...)
+      [3]
+    """
+    composite = _listen_fds_with_names(unset_environment)
+    retval = {}
+    for i in range(0, composite[0]):
+        retval[i+LISTEN_FDS_START] = composite[1+i]
+    return retval


### PR DESCRIPTION
The internal API (`system._daemon._listen_fds_with_names`) returns a tuple consisting of the count followed by the strings, closely modelling the C API without creating any unnecessary Python objects.

The external API (`systemd.daemon.listen_fds_with_names`) returns a dict of _fd_: _name_ pairs. This occurred to me as being most in line with the existing Python API for `listen_fds`.