### PR TITLE
Fix seek_realtime to work with timezone aware date

### DIFF
--- a/systemd/journal.py
+++ b/systemd/journal.py
@@ -321,7 +321,7 @@ class Reader(_Reader):
         >>> j.seek_realtime(yesterday)
         """
         if isinstance(realtime, _datetime.datetime):
-            realtime = int(float(realtime.strftime("%s.%f")) * 1000000)
+            realtime = int(float(realtime.astimezone().strftime("%s.%f")) * 1000000)
         elif not isinstance(realtime, int):
             realtime = int(realtime * 1000000)
         return super(Reader, self).seek_realtime(realtime)


### PR DESCRIPTION
`strftime("%s")` is not in the official python documentation but in my system (ubuntu 18.04 python 3.6.9) it is not aware of the object timezone and will return the wrong value if the timezone is specified and is not the system local one.

There are multiple ways to ensure a python `datetime.datetime` is in local timezone, the easiest (with python 3.3+) is to call `.astimezone()` If one wants to support earlier versions of python an extra dependency might be needed like `dateutil.tz.tzlocal()`.