### PR TITLE
Fix installation path for CentOS 8.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,9 @@ def pkgconfig(package, **kw):
     # allow version detection to be overridden using environment variables
     version = os.getenv(pkg_version)
     if not version:
-        version = check_output([pkgconf, '--modversion', package],
+        version_output = check_output([pkgconf, '--modversion', package],
                                universal_newlines=True).strip()
+        version = version_output.split()[0]
     pair = (pkg_version, version)
     defines = kw.setdefault('define_macros', [])
     if pair not in defines:


### PR DESCRIPTION
CentOS 8.3 ships systemd version 239 but has non-standart output of the
pkg-config which results in wrong version identification and setup
failure:
```
[root@aio1 ~]# pkg-config --modversion libsystemd
239 (239-41.el8_3)
[root@aio1 ~]#
```

This can be overriden with ENV var LIBSYSTEMD_VERSION but not handy.