### PR TITLE
Support realtime cutoff access

### DIFF
--- a/systemd/_reader.c
+++ b/systemd/_reader.c
@@ -883,6 +883,48 @@ static PyObject* Reader_seek_monotonic(Reader *self, PyObject *args) {
         Py_RETURN_NONE;
 }
 
+PyDoc_STRVAR(Reader_get_start__doc__,
+        "get_start() -> int\n\n"
+        "Return the realtime timestamp of the first journal entry\n\n"
+        "in microseconds.\n\n"
+        "Wraps sd_journal_get_cutoff_realtime_usec().\n"
+        "See :manpage:`sd_journal_get_cutoff_realtime_usec(3)`.");
+static PyObject* Reader_get_start(Reader *self, PyObject *args) {
+        uint64_t start, end;
+        int r;
+
+        assert(self);
+        assert(!args);
+
+        r = sd_journal_get_cutoff_realtime_usec(self->j, &start, &end);
+        if (set_error(r, NULL, NULL) < 0)
+                return NULL;
+
+        assert_cc(sizeof(unsigned long long) == sizeof(start));
+        return PyLong_FromUnsignedLongLong(start);
+}
+
+PyDoc_STRVAR(Reader_get_end__doc__,
+        "get_end() -> int\n\n"
+        "Return the realtime timestamp of the last journal entry\n\n"
+        "in microseconds.\n\n"
+        "Wraps sd_journal_get_cutoff_realtime_usec().\n"
+        "See :manpage:`sd_journal_get_cutoff_realtime_usec(3)`.");
+static PyObject* Reader_get_end(Reader *self, PyObject *args) {
+        uint64_t start, end;
+        int r;
+
+        assert(self);
+        assert(!args);
+
+        r = sd_journal_get_cutoff_realtime_usec(self->j, &start, &end);
+        if (set_error(r, NULL, NULL) < 0)
+                return NULL;
+
+        assert_cc(sizeof(unsigned long long) == sizeof(end));
+        return PyLong_FromUnsignedLongLong(end);
+}
+
 
 PyDoc_STRVAR(Reader_process__doc__,
              "process() -> state change (integer)\n\n"
@@ -1278,6 +1320,8 @@ static PyMethodDef Reader_methods[] = {
         {"seek_tail",            (PyCFunction) Reader_seek_tail, METH_NOARGS, Reader_seek_tail__doc__},
         {"seek_realtime",        (PyCFunction) Reader_seek_realtime, METH_VARARGS, Reader_seek_realtime__doc__},
         {"seek_monotonic",       (PyCFunction) Reader_seek_monotonic, METH_VARARGS, Reader_seek_monotonic__doc__},
+        {"_get_start",           (PyCFunction) Reader_get_start, METH_NOARGS, Reader_get_start__doc__},
+        {"_get_end",             (PyCFunction) Reader_get_end, METH_NOARGS, Reader_get_end__doc__},
         {"process",              (PyCFunction) Reader_process, METH_NOARGS, Reader_process__doc__},
         {"wait",                 (PyCFunction) Reader_wait, METH_VARARGS, Reader_wait__doc__},
         {"seek_cursor",          (PyCFunction) Reader_seek_cursor, METH_VARARGS, Reader_seek_cursor__doc__},

--- a/systemd/_reader.c
+++ b/systemd/_reader.c
@@ -890,13 +890,13 @@ PyDoc_STRVAR(Reader_get_start__doc__,
         "Wraps sd_journal_get_cutoff_realtime_usec().\n"
         "See :manpage:`sd_journal_get_cutoff_realtime_usec(3)`.");
 static PyObject* Reader_get_start(Reader *self, PyObject *args) {
-        uint64_t start, end;
+        uint64_t start;
         int r;
 
         assert(self);
         assert(!args);
 
-        r = sd_journal_get_cutoff_realtime_usec(self->j, &start, &end);
+        r = sd_journal_get_cutoff_realtime_usec(self->j, &start, NULL);
         if (set_error(r, NULL, NULL) < 0)
                 return NULL;
 
@@ -911,13 +911,13 @@ PyDoc_STRVAR(Reader_get_end__doc__,
         "Wraps sd_journal_get_cutoff_realtime_usec().\n"
         "See :manpage:`sd_journal_get_cutoff_realtime_usec(3)`.");
 static PyObject* Reader_get_end(Reader *self, PyObject *args) {
-        uint64_t start, end;
+        uint64_t end;
         int r;
 
         assert(self);
         assert(!args);
 
-        r = sd_journal_get_cutoff_realtime_usec(self->j, &start, &end);
+        r = sd_journal_get_cutoff_realtime_usec(self->j, NULL, &end);
         if (set_error(r, NULL, NULL) < 0)
                 return NULL;
 

--- a/systemd/journal.py
+++ b/systemd/journal.py
@@ -318,6 +318,14 @@ class Reader(_Reader):
             realtime = int(realtime * 1000000)
         return super(Reader, self).seek_realtime(realtime)
 
+    def get_start(self):
+        start = super(Reader, self)._get_start()
+        return _convert_realtime(start)
+
+    def get_end(self):
+        end = super(Reader, self)._get_end()
+        return _convert_realtime(end)
+
     def seek_monotonic(self, monotonic, bootid=None):
         """Seek to a matching journal entry nearest to `monotonic` time.
 


### PR DESCRIPTION
Output from `journalctl` is prepended with a string like:
 ```
-- Journal begins at Mon 2020-11-23 02:18:37 UTC, ends at Sat 2021-01-02 22:20:10 UTC. --
````
which is generated using the `sd_journal_get_cutoff_realtime_usec` call. This PR adds the capability to access these values from inside the python wrapper by exposing `get_start()` and `get_end()` methods on the journal object, returning a `datetime`. Addresses #84. 

It's been a while since I've used the Python C API, happy to address feedback if anyone has time. 