### PR TITLE
Adding timezone information to datetimes from systemd-journal

### DIFF
--- a/systemd/journal.py
+++ b/systemd/journal.py
@@ -51,13 +51,13 @@ def _convert_monotonic(m):
 def _convert_source_monotonic(s):
     return _datetime.timedelta(microseconds=int(s))
 
+_LOCAL_TIMEZONE = _datetime.datetime.now().astimezone().tzinfo
 
 def _convert_realtime(t):
-    return _datetime.datetime.fromtimestamp(t / 1000000)
-
+    return _datetime.datetime.fromtimestamp(t / 1000000, _LOCAL_TIMEZONE)
 
 def _convert_timestamp(s):
-    return _datetime.datetime.fromtimestamp(int(s) / 1000000)
+    return _datetime.datetime.fromtimestamp(int(s) / 1000000, _LOCAL_TIMEZONE)
 
 
 def _convert_trivial(x):

--- a/systemd/test/test_journal.py
+++ b/systemd/test/test_journal.py
@@ -290,6 +290,18 @@ def test_reader_convert_entry(tmpdir):
                    'x2' : ['YYY', 'YYY'],
                    'y2' : [b'\200\200', b'\200\201']}
 
+def test_reader_convert_timestamps(tmpdir):
+    j = journal.Reader(path=tmpdir.strpath)
+
+    val = j._convert_field('_SOURCE_REALTIME_TIMESTAMP', 1641651559324187)
+    assert val.tzinfo is not None
+
+    val = j._convert_field('__REALTIME_TIMESTAMP', 1641651559324187)
+    assert val.tzinfo is not None
+
+    val = j._convert_field('COREDUMP_TIMESTAMP', 1641651559324187)
+    assert val.tzinfo is not None
+
 def test_seek_realtime(tmpdir):
     j = journal.Reader(path=tmpdir.strpath)
 


### PR DESCRIPTION
Currently, converters for timestamp fields (__REALTIME_TIMESTAMP, _SOURCE_REALTIME_TIMESTAMP, COREDUMPTIMESTAMP) produce datetimes object without timezone, losing information.

This PR fixes that.

Without this commit :

```
>>> from systemd import journal
>>> j = journal.Reader(flags = journal.CURRENT_USER)
>>> j.seek_tail()
>>> j.get_previous().isoformat()
>>> j.get_previous()['__REALTIME_TIMESTAMP'].isoformat()
'2022-01-08T20:44:23.000494'
```

And with this commit :
```
>>> j.get_previous()['__REALTIME_TIMESTAMP'].isoformat()
'2022-01-08T20:44:23.000494+01:00'
```

Reference: [datetime.fromtimestamp](https://docs.python.org/3/library/datetime.html#datetime.datetime.fromtimestamp) : 

> If optional argument tz is None or not specified, the timestamp is converted to the platform’s local date and time, and the returned datetime object is naive.