### PR TITLE
setup.py: switch from distutils to setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import sys, os
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 from subprocess import Popen, PIPE, check_output
 
 def call(*cmd):


### PR DESCRIPTION
In Python 3.10, distutils is deprecated and slated for removal in Python
3.12. It also prevents 'setup.py bdist_wheel' from building a wheel.

Signed-off-by: Tim Orling <tim.orling@konsulko.com>