### PR TITLE
Fix use of potentially uninitialized value

### DIFF
--- a/systemd/_reader.c
+++ b/systemd/_reader.c
@@ -918,7 +918,7 @@ PyDoc_STRVAR(Reader_wait__doc__,
              "See :manpage:`sd_journal_wait(3)` for further discussion.");
 static PyObject* Reader_wait(Reader *self, PyObject *args) {
         int r;
-        int64_t timeout;
+        int64_t timeout = -1;
 
         if (!PyArg_ParseTuple(args, "|L:wait", &timeout))
                 return NULL;


### PR DESCRIPTION
From the docs:

> `|` Indicates that the remaining arguments in the Python argument list are optional. The C variables corresponding to optional arguments **should be initialized to their default value** — when an optional argument is not specified, [PyArg_ParseTuple()](https://docs.python.org/3/c-api/arg.html#c.PyArg_ParseTuple) does not touch the contents of the corresponding C variable(s).