### PR TITLE
Remove python 2 support and assume we have python 3.3+

### DIFF
--- a/systemd/_journal.c
+++ b/systemd/_journal.c
@@ -113,22 +113,6 @@ static PyMethodDef methods[] = {
         {}        /* Sentinel */
 };
 
-#if PY_MAJOR_VERSION < 3
-
-DISABLE_WARNING_MISSING_PROTOTYPES;
-PyMODINIT_FUNC init_journal(void) {
-        PyObject *m;
-
-        m = Py_InitModule("_journal", methods);
-        if (!m)
-                return;
-
-        PyModule_AddStringConstant(m, "__version__", PACKAGE_VERSION);
-}
-REENABLE_WARNING;
-
-#else
-
 static struct PyModuleDef module = {
         PyModuleDef_HEAD_INIT,
         .m_name = "_journal", /* name of module */
@@ -152,5 +136,3 @@ PyMODINIT_FUNC PyInit__journal(void) {
         return m;
 }
 REENABLE_WARNING;
-
-#endif

--- a/systemd/id128.c
+++ b/systemd/id128.c
@@ -161,26 +161,6 @@ static int add_id(PyObject *module, const char* name, sd_id128_t id) {
         return PyModule_AddObject(module, name, obj);
 }
 
-#if PY_MAJOR_VERSION < 3
-
-DISABLE_WARNING_MISSING_PROTOTYPES;
-PyMODINIT_FUNC initid128(void) {
-        PyObject *m;
-
-        m = Py_InitModule3("id128", methods, module__doc__);
-        if (!m)
-                return;
-
-        /* a series of lines like 'add_id() ;' follow */
-#define JOINER ;
-#include "id128-constants.h"
-#undef JOINER
-        PyModule_AddStringConstant(m, "__version__", PACKAGE_VERSION);
-}
-REENABLE_WARNING;
-
-#else
-
 static struct PyModuleDef module = {
         PyModuleDef_HEAD_INIT,
         .m_name = "id128", /* name of module */
@@ -209,5 +189,3 @@ PyMODINIT_FUNC PyInit_id128(void) {
         return m;
 }
 REENABLE_WARNING;
-
-#endif

--- a/systemd/journal.py
+++ b/systemd/journal.py
@@ -34,13 +34,8 @@ from ._reader import (_Reader, NOP, APPEND, INVALIDATE,
                       LOCAL_ONLY, RUNTIME_ONLY,
                       SYSTEM, SYSTEM_ONLY, CURRENT_USER,
                       OS_ROOT,
-                      _get_catalog)
+                      _get_catalog, Monotonic)
 from . import id128 as _id128
-
-if _sys.version_info >= (3,):
-    from ._reader import Monotonic
-else:
-    Monotonic = tuple
 
 
 def _convert_monotonic(m):
@@ -63,11 +58,10 @@ def _convert_timestamp(s):
 def _convert_trivial(x):
     return x
 
-if _sys.version_info >= (3,):
-    def _convert_uuid(s):
-        return _uuid.UUID(s.decode())
-else:
-    _convert_uuid = _uuid.UUID
+
+def _convert_uuid(s):
+    return _uuid.UUID(s.decode())
+
 
 DEFAULT_CONVERTERS = {
     'MESSAGE_ID': _convert_uuid,
@@ -218,9 +212,6 @@ class Reader(_Reader):
             return ans
         else:
             raise StopIteration()
-
-    if _sys.version_info < (3,):
-        next = __next__
 
     def add_match(self, *args, **kwargs):
         """Add one or more matches to the filter journal log entries.

--- a/systemd/login.c
+++ b/systemd/login.c
@@ -313,28 +313,6 @@ static PyTypeObject MonitorType = {
         .tp_new = PyType_GenericNew,
 };
 
-#if PY_MAJOR_VERSION < 3
-
-DISABLE_WARNING_MISSING_PROTOTYPES;
-PyMODINIT_FUNC initlogin(void) {
-        PyObject *m;
-
-        if (PyType_Ready(&MonitorType) < 0)
-                return;
-
-        m = Py_InitModule3("login", methods, module__doc__);
-        if (!m)
-                return;
-
-        PyModule_AddStringConstant(m, "__version__", PACKAGE_VERSION);
-
-        Py_INCREF(&MonitorType);
-        PyModule_AddObject(m, "Monitor", (PyObject *) &MonitorType);
-}
-REENABLE_WARNING;
-
-#else
-
 static struct PyModuleDef module = {
         PyModuleDef_HEAD_INIT,
         "login", /* name of module */
@@ -369,5 +347,3 @@ PyMODINIT_FUNC PyInit_login(void) {
         return m;
 }
 REENABLE_WARNING;
-
-#endif

--- a/systemd/pyutil.c
+++ b/systemd/pyutil.c
@@ -58,7 +58,6 @@ int set_error(int r, const char* path, const char* invalid_message) {
         return -1;
 }
 
-#if PY_MAJOR_VERSION >=3 && PY_MINOR_VERSION >= 1
 int Unicode_FSConverter(PyObject* obj, void *_result) {
         PyObject **result = _result;
 
@@ -76,4 +75,3 @@ int Unicode_FSConverter(PyObject* obj, void *_result) {
 
         return PyUnicode_FSConverter(obj, result);
 }
-#endif

--- a/systemd/pyutil.h
+++ b/systemd/pyutil.h
@@ -29,25 +29,13 @@ void cleanup_Py_DECREFp(PyObject **p);
 PyObject* absolute_timeout(uint64_t t);
 int set_error(int r, const char* path, const char* invalid_message);
 
-#if PY_MAJOR_VERSION >=3 && PY_MINOR_VERSION >= 1
 int Unicode_FSConverter(PyObject* obj, void *_result);
-#endif
 
 #define _cleanup_Py_DECREF_ _cleanup_(cleanup_Py_DECREFp)
 
-#if PY_MAJOR_VERSION >=3
 # define unicode_FromStringAndSize PyUnicode_FromStringAndSize
 # define unicode_FromString PyUnicode_FromString
 # define long_FromLong PyLong_FromLong
 # define long_FromSize_t PyLong_FromSize_t
 # define long_Check PyLong_Check
 # define long_AsLong PyLong_AsLong
-#else
-/* Python 3 type naming convention is used */
-# define unicode_FromStringAndSize PyString_FromStringAndSize
-# define unicode_FromString PyString_FromString
-# define long_FromLong PyInt_FromLong
-# define long_FromSize_t PyInt_FromSize_t
-# define long_Check PyInt_Check
-# define long_AsLong PyInt_AsLong
-#endif

--- a/systemd/test/test_daemon.py
+++ b/systemd/test/test_daemon.py
@@ -306,24 +306,20 @@ def test_notify_no_socket():
     assert notify('FDSTORE=1', pid=os.getpid()) is False
     assert notify('FDSTORE=1', pid=os.getpid(), fds=(1,)) is False
 
-if sys.version_info >= (3,):
-    connection_error = ConnectionRefusedError
-else:
-    connection_error = OSError
 
 def test_notify_bad_socket():
     os.environ['NOTIFY_SOCKET'] = '/dev/null'
 
-    with pytest.raises(connection_error):
+    with pytest.raises(ConnectionRefusedError):
         notify('READY=1')
-    with pytest.raises(connection_error):
+    with pytest.raises(ConnectionRefusedError):
         with skip_enosys():
             notify('FDSTORE=1', fds=[])
-    with pytest.raises(connection_error):
+    with pytest.raises(ConnectionRefusedError):
         notify('FDSTORE=1', fds=[1, 2])
-    with pytest.raises(connection_error):
+    with pytest.raises(ConnectionRefusedError):
         notify('FDSTORE=1', pid=os.getpid())
-    with pytest.raises(connection_error):
+    with pytest.raises(ConnectionRefusedError):
         notify('FDSTORE=1', pid=os.getpid(), fds=(1,))
 
 def test_notify_with_socket(tmpdir):


### PR DESCRIPTION
I had this lying around on some private branch, seeing the movement here, I remembered that I might push it. Python 2 has been EOL for 2 years now and everything older 3.7 is EOL as well, so assuming Python 3.3+ seems sensible (also nothing older thatn 3.7 is being tested).