### PR TITLE
Fixed PyPI url in last commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ On Arch:
 
 The project is also available on pypi as `systemd-python`:
 
-[![PyPI](https://img.shields.io/pypi/v/systemd-python.svg)](https://pypi.python.org/pypi)
+[![PyPI](https://img.shields.io/pypi/v/systemd-python.svg)](https://pypi.org/project/systemd-python/)
 
 To build from source
 --------------------


### PR DESCRIPTION
Missed an oopsie in #123, the url pointed to PyPI home page and not the project url. Sorry