### PR TITLE
Fix test failure

### DIFF
--- a/systemd/test/test_daemon.py
+++ b/systemd/test/test_daemon.py
@@ -349,7 +349,7 @@ def test_daemon_notify_memleak():
 
     try:
         notify('', True, 0, fds)
-    except connection_error:
+    except ConnectionRefusedError:
         pass
 
     assert sys.getrefcount(fd) <= ref_cnt, 'leak'


### PR DESCRIPTION
One usage of `connection_error` got missed when dropping Python 2 support.