### PR TITLE
docs: update intersphinx_mapping

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -275,6 +275,5 @@ epub_copyright = u'2013, David Strauss, Zbigniew Jędrzejewski-Szmek, Marti Raud
 # Allow duplicate toc entries.
 #epub_tocdup = True
 
-
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}


### PR DESCRIPTION
Newer sphinx doesn't like the old syntax:
  Running Sphinx v8.1.3
  loading translations [en]... done
  making output directory... done
  Converting `source_suffix = '.rst'` to `source_suffix = {'.rst': 'restructuredtext'}`.
  ERROR: Invalid value `None` in intersphinx_mapping['http://docs.python.org/']. Expected a two-element tuple or list.