### PR TITLE
Fixes SIGSEGV and improve thread safety of journal.Reader class

### DIFF
--- a/systemd/_reader.c
+++ b/systemd/_reader.c
@@ -468,8 +468,10 @@ static PyObject* Reader_close(Reader *self, PyObject *args) {
         assert(self);
         assert(!args);
 
-        self->closed = 1;
-        decr_ref_count(self); /* decrement initial reference (without incr) */
+        if (!self->closed) {
+                self->closed = 1;
+                decr_ref_count(self); /* decrement initial reference (without incr) */
+        }
         Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
This PR fixes threaded issues of journal.Reader class and improves its thread-safety, using simple protection with ref-counter;
It would avoid segfault by closing journal across threads.

The algorithm is simple, here short explanation illustrating the approach on an example of #143:
TH|Action|ref_count|j_handle
-|-|-|-
...|Reader created and has initial ref-count 1|1|valid
A|Enter `Reader_wait()`, increment ref-count, release the lock (GIL), enter `sd_journal_wait()`|2|valid
A|Leave `sd_journal_wait()`, acquiring the lock (GIL), decrement ref-count, not calling `sd_journal_close()` because of `ref_count == 1`, leave `Reader_wait()`|1|valid
-|... now thread A repeats the `wait()` however thread B invokes `close()` in-between ...|-|-
A|Enter `Reader_wait()`, increment ref-count, release the lock (GIL), enter `sd_journal_wait()`|2|valid
B|Enter `Reader_close()`, set closed flag, decrement ref-count, but don't close it because of `ref_count > 0`|1|valid
A|Leave `sd_journal_wait()`, acquiring the lock (GIL), decrement ref-count, calling `sd_journal_close()` because of `ref_count == 0`, leave `Reader_wait()`|0|NULL

If thread B manages to close the handle before A enters wait mode, it is also safe, because then `sd_journal_wait()` would generate EINVARG and `Reader.wait()` raises an error (`[Errno 22] Invalid argument`).

Anyway, no segfault happens anymore and it is more or less thread-safe.

closes gh-143