### PR TITLE
Workaround externally managed environment issue in Python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           sudo apt -y update
           sudo apt -y install gcc libsystemd-dev
-          python -m pip install pytest sphinx
+          python -m pip install --break-system-packages pytest sphinx
 
       - name: Build (Python ${{ matrix.python }})
         run: |

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -72,7 +72,7 @@ jobs:
         shell: bash
         run: |
           set -x
-          python3 -m pip install -I -v .
+          python3 -m pip install -I -v --break-system-packages .
           # Avoid importing the systemd module from the git repository
           cd /
           python3 -c 'from systemd import journal; print(journal.__version__)'

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -66,7 +66,7 @@ jobs:
               exit 1
           esac
 
-          python3 -m pip install pytest sphinx
+          python3 -m pip install --break-system-packages pytest sphinx
 
       - name: Build & install
         shell: bash


### PR DESCRIPTION
Around the beginning of 2025, the `ubuntu-latest` runner image which [this project uses][1], [was changed from Ubuntu 22.04 to 24.04][2].

As a result, the python version which is used by this repo's GitHub actions changed from [3.10.12][3] to [3.12.3][4].

With this change to Python 3.12, [PEP 668][5] was introduced. This new Python behavior is causing errors in the CI and `pip` is exiting non-zero

```
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.

    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.

    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.

    See /usr/share/doc/python3.13/README.venv for more information.
```

This adds a `--break-system-packages` argument to the `pip install` so that it can continue to install packages without an error.

A possible future improvement would be to do these installations in a virtual environment.

[1]: https://github.com/systemd/python-systemd/blob/903142423452c4dd18110b7f8a953dabb2031e49/.github/workflows/install.yml#L17
[2]: https://github.com/actions/runner-images/issues/10636
[3]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#installed-software
[4]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#language-and-runtime
[5]: https://peps.python.org/pep-0668/