### PR TITLE
Remove unused MANIFEST.IN

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,0 @@
-include systemd/*.h
-include README.md
-include NEWS
-include LICENSE.txt
-include Makefile
-graft docs
-exclude docs/__pycache__/*


### PR DESCRIPTION
With the switch to meson-python, meson makes the dist which includes everything required already by default. (meson-python also does not support a MANIFEST file)