### PR TITLE
Drop copyright tags

### DIFF
--- a/src/systemd/__init__.py
+++ b/src/systemd/__init__.py
@@ -1,3 +1,0 @@
-# SPDX-License-Identifier: LGPL-2.1-or-later
-#
-#  Copyright 2012 David Strauss

--- a/src/systemd/_daemon.c
+++ b/src/systemd/_daemon.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-/***
-  Copyright 2013-2016 Zbigniew Jędrzejewski-Szmek <zbyszek@in.waw.pl>
-***/
-
 #define PY_SSIZE_T_CLEAN
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wredundant-decls"

--- a/src/systemd/_journal.c
+++ b/src/systemd/_journal.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-/***
-  Copyright 2012 David Strauss <david@davidstrauss.net>
-***/
-
 #include <Python.h>
 
 #include <alloca.h>

--- a/src/systemd/_reader.c
+++ b/src/systemd/_reader.c
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
 /***
-  Copyright 2013 Steven Hiscocks, Zbigniew Jędrzejewski-Szmek
+  Copyright 2013 Steven Hiscocks
 ***/
 
 #define PY_SSIZE_T_CLEAN

--- a/src/systemd/_reader.c
+++ b/src/systemd/_reader.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-/***
-  Copyright 2013 Steven Hiscocks
-***/
-
 #define PY_SSIZE_T_CLEAN
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wredundant-decls"

--- a/src/systemd/id128.c
+++ b/src/systemd/id128.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-/***
-  Copyright 2013 Zbigniew Jędrzejewski-Szmek <zbyszek@in.waw.pl>
-***/
-
 #include <Python.h>
 
 /* Our include is first, so that our defines are replaced by the ones

--- a/src/systemd/journal.py
+++ b/src/systemd/journal.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
 #  Copyright 2012 David Strauss <david@davidstrauss.net>
-#  Copyright 2012 Zbigniew Jędrzejewski-Szmek <zbyszek@in.waw.pl>
 #  Copyright 2012 Marti Raudsepp <marti@juffo.org>
 
 import sys as _sys

--- a/src/systemd/journal.py
+++ b/src/systemd/journal.py
@@ -1,6 +1,4 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
-#
-#  Copyright 2012 Marti Raudsepp <marti@juffo.org>
 
 import sys as _sys
 import datetime as _datetime

--- a/src/systemd/journal.py
+++ b/src/systemd/journal.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 #
-#  Copyright 2012 David Strauss <david@davidstrauss.net>
 #  Copyright 2012 Marti Raudsepp <marti@juffo.org>
 
 import sys as _sys

--- a/src/systemd/login.c
+++ b/src/systemd/login.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-/***
-  Copyright 2013 Zbigniew Jędrzejewski-Szmek <zbyszek@in.waw.pl>
-***/
-
 #define PY_SSIZE_T_CLEAN
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wredundant-decls"

--- a/src/systemd/macro.h
+++ b/src/systemd/macro.h
@@ -2,10 +2,6 @@
 
 #pragma once
 
-/***
-  Copyright 2010 Lennart Poettering
-***/
-
 #define DISABLE_WARNING_MISSING_PROTOTYPES                              \
         _Pragma("GCC diagnostic push");                                 \
         _Pragma("GCC diagnostic ignored \"-Wmissing-prototypes\"")

--- a/src/systemd/pyutil.c
+++ b/src/systemd/pyutil.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-/***
-  Copyright 2013 Zbigniew Jędrzejewski-Szmek <zbyszek@in.waw.pl>
-***/
-
 #include <Python.h>
 #include "pyutil.h"
 

--- a/src/systemd/pyutil.h
+++ b/src/systemd/pyutil.h
@@ -2,10 +2,6 @@
 
 #pragma once
 
-/***
-  Copyright 2013 Zbigniew Jędrzejewski-Szmek <zbyszek@in.waw.pl>
-***/
-
 #ifndef Py_TYPE
 /* avoid duplication warnings from errors in Python 2.7 headers */
 # include <Python.h>

--- a/src/systemd/strv.c
+++ b/src/systemd/strv.c
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-/***
-  Copyright 2010 Lennart Poettering
-***/
-
 #include <stdlib.h>
 
 void strv_clear(char **l) {

--- a/src/systemd/strv.h
+++ b/src/systemd/strv.h
@@ -1,9 +1,5 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
 
-/***
-  Copyright 2010 Lennart Poettering
-***/
-
 #include "macro.h"
 
 char **strv_free(char **l);

--- a/src/systemd/util.c
+++ b/src/systemd/util.c
@@ -1,7 +1,4 @@
 /* SPDX-License-Identifier: LGPL-2.1-or-later */
-/***
-  Copyright 2010 Lennart Poettering
-***/
 
 /* stuff imported from systemd without any changes */
 

--- a/src/systemd/util.h
+++ b/src/systemd/util.h
@@ -2,10 +2,6 @@
 
 #pragma once
 
-/***
-  Copyright 2010 Lennart Poettering
-***/
-
 #include <netinet/ip.h>
 #include <arpa/inet.h>
 


### PR DESCRIPTION
@poettering, @davidstrauss, @intgr, @kwirk please give your acks.
This mirrors the change that was done in systemd and in other projects.
The copyright is preserved even without an explicit copyright line, and those
lines get our of sync with the actual history of edits in a file, so let's drop them.
The copyright and license is still maintained.