### PR TITLE
meson: build docs with meson

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,13 +43,6 @@ clean:
 distclean: clean
 	rm -rf dist MANIFEST
 
-SPHINXOPTS += -D version=$(VERSION) -D release=$(VERSION)
-sphinx-%: install
-	mkdir $(BUILD_DIR) && cd $(BUILD_DIR) && $(PYTHON) -m sphinx -b $* $(SPHINXOPTS) ../docs $*
-	@echo Output has been generated in $(BUILD_DIR)/$*
-
-doc: sphinx-html
-
 check: build install
 	($(PYTHON) -m pytest src/systemd/test docs $(TESTFLAGS))
 

--- a/meson.build
+++ b/meson.build
@@ -21,3 +21,17 @@ common_c_args = [
 ]
 
 subdir('src/systemd')
+
+# Docs
+sphinx_build = find_program('sphinx-build', disabler: true, required: get_option('docs'))
+if get_option('docs')
+        sphinx_args = ['-Dversion=' + meson.project_version(), '-Drelease=' + meson.project_version()]
+        input_dir = meson.current_source_dir() / 'docs'
+        output_dir = meson.current_build_dir() / 'html'
+        output_file = output_dir / 'index.html'
+        custom_target('build-docs',
+                output: 'index.html',
+                input: files('docs/conf.py'),
+                command: [sphinx_build, '-b', 'html', sphinx_args, input_dir, output_dir],
+        )
+endif

--- a/meson.options
+++ b/meson.options
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+option('docs', type : 'boolean', value : false)


### PR DESCRIPTION
Introduce a custom target `build-docs` to build the sphinx documentation.