### PR TITLE
meson: copy .py files to build directory

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -28,4 +28,15 @@ update_constants_py = files('update-constants.py')
 
 subdir('src/systemd')
 
+test(
+        'unit',
+        find_program(python.full_path()),
+        args: [
+                '-m', 'pytest',
+                '-v',
+                python_test_dir,
+              ],
+        env: { 'PYTHONPATH': meson.current_build_dir() / 'src' },
+)
+
 alias_target('update-constants', update_constants)

--- a/src/systemd/meson.build
+++ b/src/systemd/meson.build
@@ -58,6 +58,7 @@ foreach file: py_files
 endforeach
 
 # Test code
+python_test_dir = meson.current_source_dir() / 'test'
 python.install_sources(
         'test/test_daemon.py',
         'test/test_journal.py',


### PR DESCRIPTION
This seems to do the trick:
```console
$ ninja -C build
$ PYTHONPATH=build/src/ python -c 'from systemd import id128; print(id128)'
<module 'systemd.id128' from '/home/zbyszek/src/python-systemd/build/src/systemd/id128.cpython-313-x86_64-linux-gnu.so'>
$ PYTHONPATH=build/src/ pytest build/src/systemd/test ...
============================ test session starts ============================= platform linux -- Python 3.13.4, pytest-8.3.4, pluggy-1.5.0 rootdir: /home/zbyszek/src/python-systemd
configfile: pyproject.toml
plugins: ...
collected 61 items

build/src/systemd/test/test_daemon.py ........................         [ 39%]
build/src/systemd/test/test_id128.py ....                              [ 45%]
build/src/systemd/test/test_journal.py ............................    [ 91%]
build/src/systemd/test/test_login.py .....                             [100%]

============================= 61 passed in 0.21s =============================
```
