### PR TITLE
meson: dynamically generate version from tag

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,3 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,abbrev=9,match=*[0-9]*)$

--- a/generate_version.py
+++ b/generate_version.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+
+from datetime import datetime
+from typing import Optional
+
+
+def git_describe() -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "describe", "--abbrev=9", "--tags", "--match=*[0-9]*"],
+        text=True,
+        capture_output=True,
+    )
+
+
+def version_from_git_describe(desc: str, timestamp: Optional[datetime] = None) -> str:
+    desc = desc.removeprefix("v").strip()
+    version, *rest = desc.split("-", maxsplit=2)
+    # we're directly on a tag
+    if not rest:
+        return version
+
+    # guess next version
+    version_parts = [int(v) for v in version.split(".")]
+    version_parts.append(version_parts.pop() + 1)
+
+    # dev tailer
+    commits_since_tag, commit = rest
+    t = timestamp or datetime.now()
+    trailer = f".dev{commits_since_tag}+{commit}.d{t:%Y%m%d}"
+
+    return ".".join(str(v) for v in version_parts) + trailer
+
+
+def read_git_archival_txt() -> dict[str, str]:
+    archive = {}
+    with open(".git_archival.txt") as txt:
+        for line in txt.read().splitlines():
+            key, var = line.split(":", maxsplit=1)
+            archive[key.strip()] = var.strip()
+    return archive
+
+
+def version_from_archival_txt(info: dict[str, str], timestamp: Optional[datetime] = None) -> str:
+    desc = info['describe-name']
+
+    t = timestamp or datetime.fromisoformat(info['node-date'])
+    return version_from_git_describe(desc, timestamp=t)
+
+
+def main() -> str:
+    # if SOURCE_DATE_EPOCH is set, we're going to use it as the timestamp
+    sde = None
+    if (t := os.environ.get("SOURCE_DATE_EPOCH")) is not None:
+        sde = datetime.fromtimestamp(int(t))
+
+    p = git_describe()
+    if p.returncode == 0:
+        return version_from_git_describe(p.stdout, timestamp=sde)
+    elif p.returncode == 128:  # not a git repo
+        info = read_git_archival_txt()
+        return version_from_archival_txt(info, timestamp=sde)
+
+    return "unknown"
+
+
+if __name__ == "__main__":
+    print(main())

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@
 project(
         'python-systemd',
         'c',
-        version: '236',
+        version: run_command(meson.project_source_root() / 'generate_version.py', check: true).stdout().strip(),
         license: 'LGPL-2.1-or-later',
         default_options: ['warning_level=2', 'c_std=c99'],
         meson_version: '>= 1.8.0',


### PR DESCRIPTION
This is mostly a slim reimplementation of `setuptool_scm`. It seems broken with editable installs, but I think that might be a meson bug, I'm not sure yet.