### PR TITLE
Journald GIL release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.11-slim
+
+# Install compilation dependencies
+RUN apt-get update && apt-get install -y \
+    gcc \
+    pkg-config \
+    libsystemd-dev \
+    make \
+    git \
+    meson \
+    jq \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir wheel build
+
+WORKDIR /src
+
+# Fix git ownership issue
+RUN git config --global --add safe.directory /src

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,14 @@ all: build
 build:
 	$(PYTHON) -m build -Cbuild-dir=$(BUILD_DIR)
 
+wheel:
+	rm -rf $(BUILD_DIR)
+	$(PYTHON) -m build --wheel -Cbuild-dir=$(BUILD_DIR) -Csetup-args="-Djournal_unlock_gil=1"
+
+wheel_gil:
+	rm -rf $(BUILD_DIR)
+	$(PYTHON) -m build --wheel -Cbuild-dir=$(BUILD_DIR) -Csetup-args="-Djournal_unlock_gil=0"
+
 install:
 	$(PYTHON) -m pip install .
 
@@ -24,7 +32,7 @@ sign: dist/systemd-python-$(VERSION).tar.gz
 	gpg --detach-sign -a dist/systemd-python-$(VERSION).tar.gz
 
 clean:
-	rm -rf $(BUILD_DIR) systemd/*.so systemd/*.py[co] *.py[co] systemd/__pycache__
+	rm -rf $(BUILD_DIR) systemd/*.so systemd/*.py[co] *.py[co] systemd/__pycache__ dist
 
 distclean: clean
 	rm -rf dist MANIFEST

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ is separated into a number of modules:
 - `systemd.login` wraps parts of `libsystemd` used to query logged in users
   and available seats and machines.
 
+
 Installation
 ============
 
@@ -41,14 +42,33 @@ The project is also available on pypi as `systemd-python`:
 To build from source
 --------------------
 
-On CentOS, RHEL, and Fedora:
+### On CentOS, RHEL, and Fedora:
 
     dnf install git python3-pip gcc python3-devel systemd-devel
     pip3 install 'git+https://github.com/systemd/python-systemd.git#egg=systemd-python'
 
-On Debian or Ubuntu:
+### On Debian or Ubuntu:
 
-    apt install libsystemd-{journal,daemon,login,id128}-dev gcc python3-dev pkg-config
+make is mirrored into docker-compose, to turn the build independent of packages installed
+
+    mkdir dist
+    mkdir build
+
+to run make all:
+
+    docker compose run --rm make
+
+to run any make command
+
+    docker compose run --rm make $command
+
+for example
+
+    docker compose run --rm make wheel
+    docker compose run --rm make clean
+    docker compose run --rm make build
+    docker compose run --rm make check
+
 
 Usage
 =====
@@ -133,7 +153,7 @@ Show kernel ring buffer (`journalctl -k`):
         print(entry['MESSAGE'])
 
 Read entries in reverse (`journalctl _EXE=/usr/bin/vim -r`):
-  
+
     from systemd import journal
     class ReverseReader(journal.Reader):
         def __next__(self):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  make:
+    build: .
+    volumes:
+      - .:/src
+      - ./build:/build
+      - ./dist:/dist
+    entrypoint: /usr/bin/make
+    command: all

--- a/meson.build
+++ b/meson.build
@@ -21,6 +21,7 @@ add_project_arguments(
         '-D_GNU_SOURCE=1',
         '-DPACKAGE_VERSION="@0@"'.format(meson.project_version()),
         '-DLIBSYSTEMD_VERSION=@0@'.format(libsystemd_dep.version()),
+        '-DSD_JOURNAL_SENDV_UNLOCK_GIL=@0@'.format(get_option('journal_unlock_gil')),
         language : 'c',
 )
 

--- a/meson.options
+++ b/meson.options
@@ -1,3 +1,4 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 option('docs', type : 'boolean', value : false)
+option('journal_unlock_gil', type: 'integer', value: 1, description: 'unlock gil before sending log to journal')

--- a/src/systemd/_journal.c
+++ b/src/systemd/_journal.c
@@ -8,6 +8,14 @@
 #include "macro.h"
 #include "pyutil.h"
 
+
+#if defined(SD_JOURNAL_SENDV_UNLOCK_GIL) && (SD_JOURNAL_SENDV_UNLOCK_GIL == 1)
+#define JOURNAL_SENDV_UNLOCK_GIL  1
+#else
+#define JOURNAL_SENDV_UNLOCK_GIL  0
+#endif
+
+
 PyDoc_STRVAR(journal_sendv__doc__,
              "sendv('FIELD=value', 'FIELD=value', ...) -> None\n\n"
              "Send an entry to the journal."
@@ -43,8 +51,14 @@ static PyObject* journal_sendv(PyObject *self _unused_, PyObject *args) {
                 iov[i].iov_len = length;
         }
 
+#if (JOURNAL_SENDV_UNLOCK_GIL == 1)
+        Py_BEGIN_ALLOW_THREADS
+#endif
         /* Send the iovector to the journal. */
         r = sd_journal_sendv(iov, argc);
+#if (JOURNAL_SENDV_UNLOCK_GIL == 1)
+        Py_END_ALLOW_THREADS
+#endif
         if (r < 0) {
                 errno = -r;
                 PyErr_SetFromErrno(PyExc_OSError);
@@ -107,6 +121,11 @@ PyMODINIT_FUNC PyInit__journal(void) {
                 return NULL;
 
         if (PyModule_AddStringConstant(m, "__version__", PACKAGE_VERSION)) {
+                Py_DECREF(m);
+                return NULL;
+        }
+
+        if (PyModule_AddIntConstant(m, "__sendv_unlock_gil__", JOURNAL_SENDV_UNLOCK_GIL)) {
                 Py_DECREF(m);
                 return NULL;
         }

--- a/src/systemd/journal.py
+++ b/src/systemd/journal.py
@@ -9,7 +9,7 @@ import logging as _logging
 from syslog import (LOG_EMERG, LOG_ALERT, LOG_CRIT, LOG_ERR,
                     LOG_WARNING, LOG_NOTICE, LOG_INFO, LOG_DEBUG)
 
-from ._journal import __version__, sendv, stream_fd
+from ._journal import __version__, sendv, stream_fd, __sendv_unlock_gil__
 from ._reader import (_Reader, NOP, APPEND, INVALIDATE,
                       LOCAL_ONLY, RUNTIME_ONLY,
                       SYSTEM, SYSTEM_ONLY, CURRENT_USER,
@@ -537,6 +537,15 @@ class JournalHandler(_logging.Handler):
 
         self.send = sender_function
         self._extra = kwargs
+
+    @staticmethod
+    def gil_unlocked():
+        """Return whether the journal send function is configured to unlock the GIL.
+
+        This is useful for logging handlers to determine whether they can safely
+        call the send function without risking deadlocks.
+        """
+        return __sendv_unlock_gil__ == 1
 
     @classmethod
     def with_args(cls, config=None):


### PR DESCRIPTION
When calling to sendv from journald handler, GIL is not released hence any issue with Journald causes every other thread to hang until the call is complete,

* added gil release / gil acquire around sendv, as well as a compilation flag to disable it
* added a docker-compose for convenient local build 