### PR TITLE
Update Debian install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ On CentOS, RHEL, and Fedora:
 
 On Debian or Ubuntu:
 
-    apt install libsystemd-{journal,daemon,login,id128}-dev gcc python3-dev pkg-config
+    apt install libsystemd-dev gcc python3-dev pkg-config
 
 Usage
 =====


### PR DESCRIPTION
Systemd has had a single -dev binary package since ~2014, so these have not worked for a long time.

Noted in #138 (but not the main thrust of the issue)